### PR TITLE
perf: split post data for optimal performance!(#11)

### DIFF
--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default async function PostDetail({ params }: Props) {
   const { slug } = await params;
 
-  const post = getPostBySlug(slug);
+  const post = await getPostBySlug(slug);
 
   if (!post) return <ErrorResult status="404" back="prev" />;
 

--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { getAllPost } from '~/utils/postData';
+import { getPostList } from '~/utils/postData';
 import dayjs from 'dayjs';
 
-export default function PostList() {
-  const allPosts = getAllPost();
+export default async function PostList() {
+  const allPosts = await getPostList();
 
   return (
     <ul className="m-0 p-0">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,8 @@
-import allPosts from '~/generated/content.json';
+import catalogs from '~/generated/catalog.json';
 import { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const posts = allPosts.map((post) => ({
+  const posts = catalogs.map((post) => ({
     url: `${process.env.NEXT_PUBLIC_SITE_HOST}/post/${post.slug}`,
     lastModified: post.publishedAt,
   }));

--- a/components/layouts/page-header/search.ts
+++ b/components/layouts/page-header/search.ts
@@ -1,15 +1,15 @@
 import { Document } from 'flexsearch';
 import FlexSearchDocument from 'flexsearch/dist/module/document';
 // import { tokenizer } from '~/utils/mixTokenizer';
-import { getAllPost } from '~/utils/postData';
-import { fromMarkdown } from 'mdast-util-from-markdown';
-import { nanoid } from 'nanoid';
+// import { getPostList } from '~/utils/postData';
+// import { fromMarkdown } from 'mdast-util-from-markdown';
+// import { nanoid } from 'nanoid';
 
 // const tags = ['Tabs', 'Video', 'ImageWrap', 'ImageLayout', 'Row', 'Col'];
 // const tagStr = tags.join('|');
 // const reg_replace = new RegExp(`<(${tagStr})s+[^>]*>|</(${tagStr})s*>`, 'g');
 
-type AstRoot = ReturnType<typeof fromMarkdown>;
+// type AstRoot = ReturnType<typeof fromMarkdown>;
 export interface IndexItem {
   id: string;
   link: string;
@@ -33,8 +33,8 @@ const index: Document<IndexItem, true> = new FlexSearchDocument({
     bidirectional: true,
   },
 });
-const allPost = getAllPost();
-praseAst();
+// const allPost = await getPostList();
+// praseAst();
 
 export default function searchDoc(query?: string) {
   if (!query) return [];
@@ -42,90 +42,90 @@ export default function searchDoc(query?: string) {
   return searchResult;
 }
 
-function getText(item: AstRoot['children'][number]) {
-  if ('children' in item) {
-    return item.children.reduce((total, item) => {
-      if ('children' in item) {
-        total += getText(item);
-      } else {
-        if ('value' in item) {
-          total += item.value;
-        }
-      }
+// function getText(item: AstRoot['children'][number]) {
+//   if ('children' in item) {
+//     return item.children.reduce((total, item) => {
+//       if ('children' in item) {
+//         total += getText(item);
+//       } else {
+//         if ('value' in item) {
+//           total += item.value;
+//         }
+//       }
 
-      return total;
-    }, '');
-  } else {
-    if ('value' in item) {
-      return item.value;
-    }
-  }
+//       return total;
+//     }, '');
+//   } else {
+//     if ('value' in item) {
+//       return item.value;
+//     }
+//   }
 
-  return '';
-}
+//   return '';
+// }
 
-function praseAst() {
-  allPost.forEach((post) => {
-    const ast = fromMarkdown(post.content);
-    const items = ast.children;
+// function praseAst() {
+//   allPost.forEach((post) => {
+//     const ast = fromMarkdown(post.content);
+//     const items = ast.children;
 
-    const headings = [] as Array<{ title: string; level: number }>;
+//     const headings = [] as Array<{ title: string; level: number }>;
 
-    items.forEach((item) => {
-      const prev_heading = headings.at(-1);
+//     items.forEach((item) => {
+//       const prev_heading = headings.at(-1);
 
-      let targetItem: IndexItem | null = null;
-      const id = nanoid(6);
+//       let targetItem: IndexItem | null = null;
+//       const id = nanoid(6);
 
-      if (item.type === 'heading') {
-        if (prev_heading) {
-          if (prev_heading.level < item.depth) {
-            headings.push({ title: getText(item), level: item.depth });
-          } else if (prev_heading.level === item.depth) {
-            headings.pop();
+//       if (item.type === 'heading') {
+//         if (prev_heading) {
+//           if (prev_heading.level < item.depth) {
+//             headings.push({ title: getText(item), level: item.depth });
+//           } else if (prev_heading.level === item.depth) {
+//             headings.pop();
 
-            headings.push({ title: getText(item), level: item.depth });
-          } else if (prev_heading.level > item.depth) {
-            while (headings.at(-1)!.level > item.depth) {
-              headings.pop();
-            }
+//             headings.push({ title: getText(item), level: item.depth });
+//           } else if (prev_heading.level > item.depth) {
+//             while (headings.at(-1)!.level > item.depth) {
+//               headings.pop();
+//             }
 
-            if (headings.at(-1)!.level === item.depth) {
-              headings.pop();
+//             if (headings.at(-1)!.level === item.depth) {
+//               headings.pop();
 
-              headings.push({ title: getText(item), level: item.depth });
-            } else {
-              headings.push({ title: getText(item), level: item.depth });
-            }
-          }
-        } else {
-          headings.push({ title: getText(item), level: item.depth });
-        }
+//               headings.push({ title: getText(item), level: item.depth });
+//             } else {
+//               headings.push({ title: getText(item), level: item.depth });
+//             }
+//           }
+//         } else {
+//           headings.push({ title: getText(item), level: item.depth });
+//         }
 
-        targetItem = {
-          id,
-          link: post.url,
-          type: 'heading',
-          headings: headings.map((item) => item.title).join('>'),
-          content: getText(item),
-        };
-      } else {
-        let content: string = getText(item);
+//         targetItem = {
+//           id,
+//           link: post.url,
+//           type: 'heading',
+//           headings: headings.map((item) => item.title).join('>'),
+//           content: getText(item),
+//         };
+//       } else {
+//         let content: string = getText(item);
 
-        content = content./* replaceAll(reg_replace, ''). */ replaceAll('\n', '');
+//         content = content./* replaceAll(reg_replace, ''). */ replaceAll('\n', '');
 
-        if (content) {
-          targetItem = {
-            id,
-            link: post.url,
-            type: 'content',
-            headings: headings.map((item) => item.title).join('>'),
-            content,
-          };
-        }
-      }
+//         if (content) {
+//           targetItem = {
+//             id,
+//             link: post.url,
+//             type: 'content',
+//             headings: headings.map((item) => item.title).join('>'),
+//             content,
+//           };
+//         }
+//       }
 
-      if (targetItem) index.add(targetItem);
-    });
-  });
-}
+//       if (targetItem) index.add(targetItem);
+//     });
+//   });
+// }

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,9 +13,9 @@ const imageRemotes: RemotePattern[] = [
 }));
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
+  // output: 'standalone',
   reactStrictMode: true,
-  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx', 'json'],
   // https://github.com/hashicorp/next-mdx-remote?tab=readme-ov-file#installation
   transpilePackages: ['next-mdx-remote'],
   images: {

--- a/utils/postData.ts
+++ b/utils/postData.ts
@@ -1,14 +1,14 @@
-import allPosts from '~/generated/content.json';
-import { PostJsonData } from '~/scripts/content';
+import type { PostJsonData } from '~/scripts/content';
 
-// only format type
-const posts = allPosts as unknown as PostJsonData[];
+type BaseList = Omit<PostJsonData, 'content'>;
 
-export function getAllPost() {
-  return posts;
+export async function getPostList() {
+  const postList = await import(`~/generated/catalog.json`);
+
+  return postList.default as BaseList[];
 }
 
-export function getPostBySlug(slug: string) {
-  const post = allPosts.find((post) => post.slug === slug);
-  return post;
+export async function getPostBySlug(slug: string) {
+  const post = await import(`~/generated/${slug}.json`);
+  return post as PostJsonData;
 }


### PR DESCRIPTION
## 问题
所有文章打包至一个文件中，搜索全局使用，导致初次加载必定会将大体积的文章js加载，即使不使用搜索，导致首次加载时可能出现不必要的文件

## 修改方案

将文章分路由打包，每篇文章对应一个js文件，最小化体积

性能优化前：

![image](https://github.com/user-attachments/assets/56fcfe6e-c0cb-4448-ad09-d8529055ff9f)
![image](https://github.com/user-attachments/assets/5fd5c57c-7ad7-4f3f-b8b1-29c822987709)

性能优化后：

![image](https://github.com/user-attachments/assets/4331a681-3281-4460-a77b-e74b26f7045c)

## 影响

性能优化导致部分设计上的功能重构，搜索功能暂时停止

